### PR TITLE
build: bump bundler version to resolve CVE-2019-3881

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
 rvm:
+  - "2.6.5"
   - "2.1.1"
   - "2.0.0"
   - "1.9.3"
   - jruby-19mode # JRuby in 1.9 mode
+before_install: gem install bundler --no-rdoc --no-ri
 script: bundle exec rspec spec

--- a/excel_csv.gemspec
+++ b/excel_csv.gemspec
@@ -1,22 +1,20 @@
-# coding: utf-8
 Gem::Specification.new do |spec|
-  spec.name          = "excel_csv"
-  spec.version       = "0.0.3"
-  spec.authors       = ["Marketplacer"]
-  spec.email         = ["it@marketplacer.com"]
-  spec.summary       = %q{Read & write CSV that can be used reliably by Microsoft Excel}
-  spec.description   = %q{}
-  spec.homepage      = ""
-  spec.license       = "MIT"
+  spec.name = 'excel_csv'
+  spec.version = '0.0.3'
+  spec.authors = ['Marketplacer']
+  spec.email = ['it@marketplacer.com']
+  spec.summary = 'Read & write CSV that can be used reliably by Microsoft Excel'
+  spec.description = ''
+  spec.homepage = ''
+  spec.license = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.files = `git ls-files -z`.split("\x0")
+  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "activesupport"
-
+  spec.add_development_dependency 'activesupport'
+  spec.add_development_dependency 'bundler', '>= 2.1.0'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
 end


### PR DESCRIPTION
CVE-2019-3881
high severity
Vulnerable versions: >= 1.14.0, < 2.1.0
Patched version: 2.1.0
Bundler prior to 2.1.0 uses a predictable path in /tmp/, created with
insecure permissions as a storage location for gems, if locations under
the user's home directory are not available. If Bundler is used in a
scenario where the user does not have a writable home directory, an
attacker could place malicious code in this directory that would be
later loaded and executed.